### PR TITLE
Projects now use relative paths and close project hook

### DIFF
--- a/Workspaces/QRiS_DEV.code-workspace
+++ b/Workspaces/QRiS_DEV.code-workspace
@@ -43,7 +43,7 @@
 			"PATH": "${env:PATH}:${env:QGIS_PATH}/Contents/MacOS/bin"
 		},
 		// NOTE: For this to work you need an env file with "QGIS_PATH=/Applications/QGIS-LTR.app/Contents" or whatever your path is
-    "python.pythonPath": "${env:QGIS_PATH}/Contents/MacOS/bin/python3.9",
+    "python.pythonPath": "${env:QGIS_PATH}/Contents/MacOS/bin/python3",
 		"qtForPython.uic.args": [
 			"-o \"${workspaceFolder}${pathSeparator}src${pathSeparator}view${pathSeparator}ui${pathSeparator}${fileBasenameNoExtension}.py\""
 		],

--- a/src/model/project.py
+++ b/src/model/project.py
@@ -129,3 +129,39 @@ def parse_posix_path(path: str) -> str:
     """
     new_path = PurePosixPath(path.replace('\\', '/'))
     return str(new_path)
+
+
+def safe_make_relpath(in_path: str, cwd_path: str) -> str:
+    """ Safely create an absolute path from a relative path
+
+    if this fails then just return the input
+
+    Args:
+        in_path (str): _description_
+        cwd_path (str): _description_
+
+    Returns:
+        str: _description_
+    """
+    if in_path and len(in_path) > 0 and os.path.isabs(in_path):
+        return os.path.relpath(in_path, cwd_path)
+    else:
+        return in_path
+
+
+def safe_make_abspath(in_path: str,cwd_path: str) -> str:
+    """ Safely create an absolute path from a relative path
+
+    if this fails then just return the input
+
+    Args:
+        in_path (str): _description_
+        cwd_path (str): _description_
+
+    Returns:
+        str: _description_
+    """
+    if in_path and len(in_path) > 0 and not os.path.isabs(in_path):
+        return os.path.abspath(os.path.join(cwd_path, in_path))
+    else:
+        return in_path

--- a/src/view/frm_dockwidget.py
+++ b/src/view/frm_dockwidget.py
@@ -133,10 +133,6 @@ class QRiSDockWidget(QtWidgets.QDockWidget):
         """
         self.project = Project(project_file)
 
-        # Save the project in the QGIS Project (QGZ) so that it can be reloaded when
-        # the QGZ is next opened
-        QgsProject.instance().writeEntry(CONSTANTS['settingsCategory'], CONSTANTS['qris_project_path'], project_file)
-
         self.model = QtGui.QStandardItemModel()
         self.treeView.setModel(self.model)
         self.tree_state = {}
@@ -678,3 +674,4 @@ class QRiSDockWidget(QtWidgets.QDockWidget):
         self.treeView.header().setSortIndicatorShown(False)
         self.gridLayout.addWidget(self.treeView, 0, 0, 1, 1)
         self.setWidget(self.dockWidgetContents)
+

--- a/src/view/frm_stream_gage_docwidget.py
+++ b/src/view/frm_stream_gage_docwidget.py
@@ -5,8 +5,10 @@ from datetime import date
 from PyQt5 import QtCore, QtGui, QtWidgets
 import matplotlib
 from qgis import core, gui, utils
-from qgis.core import QgsApplication, Qgis
+from qgis.core import QgsApplication, Qgis, QgsMessageLog
 from PyQt5.QtCore import pyqtSlot
+
+from ..QRiS.settings import CONSTANTS
 
 # from qgis.core import QgsMapLayer
 # from qgis.gui import QgsDataSourceSelectDialog
@@ -22,10 +24,14 @@ from ..gp.stream_gage_discharge_task import StreamGageDischargeTask
 
 # https://stackoverflow.com/questions/31406193/matplotlib-is-not-worked-with-qgis
 # https://matplotlib.org/3.1.1/gallery/user_interfaces/embedding_in_qt_sgskip.html
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.figure import Figure
-import matplotlib.dates as mdates
-import matplotlib.ticker as ticker
+try:
+    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+    from matplotlib.figure import Figure
+    import matplotlib.dates as mdates
+    import matplotlib.ticker as ticker
+except ImportError:
+    QgsMessageLog.logMessage(f"Matplotlib is not at a sufficient version: {matplotlib.__version__}", CONSTANTS['logCategory'], level=Qgis.Critical)
+
 
 # Help on selection changed event
 # https://stackoverflow.com/questions/10156842/howto-get-the-selectionchanged-signal


### PR DESCRIPTION
There are 4 main changes here:

1. A minor workspace change to make the minor version of python agnostic
2. The close project button has been enabled and the "close project" button will have the same functionality
3. Projects now use relative paths
4. Matplotlib now has an import check so we can keep things functional on LTR. FrmStreamGageDocWidget still won't work on LTR but at least everything else will.